### PR TITLE
Add a CURLOPT setting SSL_VERIFYHOST to false

### DIFF
--- a/development/api-client-php.md
+++ b/development/api-client-php.md
@@ -102,6 +102,7 @@ class EspoApiClient
         }
 
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_USERAGENT, $this->userAgent);
         curl_setopt($ch, CURLOPT_HEADER, true);


### PR DESCRIPTION
I had to add a Curl Opt to set VERIFYHOST to false to get requests to my Espo server using a self-signed certificate. This does however leave the possibility for MITM attacks open.