### PR TITLE
Fix support for non JSON attachments

### DIFF
--- a/docs/development/api-client-php.md
+++ b/docs/development/api-client-php.md
@@ -198,6 +198,11 @@ class EspoApiClient
                 return json_decode($parsedResponse['body'], true);
             }
 
+            if (substr($responseContentType, 0, 12) === "application/") {
+                //echo $action;
+                return $parsedResponse['body'];
+            }
+
             return $parsedResponse['body'];
         }
 


### PR DESCRIPTION
I made this patch locally in order to handle .pdf and .docx files which were failing to load because the class was only handling `application/json` file types.