### PR TITLE
Updated links to deal with changed GitHub username

### DIFF
--- a/docs/development/api-client-java.md
+++ b/docs/development/api-client-java.md
@@ -3,12 +3,12 @@
 - [Installing](#installing)
 - [Usage](#usage)
 
-For the source code, refer to the GitHub repository [here](https://github.com/TheDutchMC/espocrm-java).
+For the source code, refer to the GitHub repository [here](https://github.com/TobiasDeBruijn/espocrm-java).
 
 ## Installing
 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.array21/espocrm-api-client.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22dev.array21%22%20AND%20a:%22espocrm-api-client%22)
-[![Build Status](https://drone.k8s.array21.dev/api/badges/TheDutchMC/espocrm-java/status.svg)](https://drone.k8s.array21.dev/TheDutchMC/espocrm-java)
+[![Build Status](https://drone.k8s.array21.dev/api/badges/TobiasDeBruijn/espocrm-java/status.svg)](https://drone.k8s.array21.dev/TobiasDeBruijn/espocrm-java)
 
 The client is available on the Maven Central repository.  
 Minimum supported Java version: 11

--- a/docs/development/api-client-rust.md
+++ b/docs/development/api-client-rust.md
@@ -6,7 +6,7 @@
 * [Making a request](#making-a-request)
 
 For the full documentation, refer to [docs.rs](https://docs.rs/espocrm-rs/latest/espocrm_rs/).
-For the source code, refer to [GitHub](https://github.com/TheDutchMC/espocrm-rs).
+For the source code, refer to [GitHub](https://github.com/TobiasDeBruijn/espocrm-rs).
 
 ## Installation
 [![Crates.io](https://img.shields.io/crates/v/espocrm-rs)](https://crates.io/crates/espocrm-rs)  


### PR DESCRIPTION
I've updated my GitHub username, as a result of this the links in the docs should be updated to reflect this change. The old links continue working as long as no new user takes my old name and creates a repository with the same name.

This affects the docs for the Rust and Java client.

Thanks.