### PR TITLE
Four Ms to displaying full name of the month

### DIFF
--- a/docs/administration/date-formatting.md
+++ b/docs/administration/date-formatting.md
@@ -3,7 +3,7 @@
 * `YYYY` – 4 digit year: `2020`
 * `YY` – 2 digit year: `20`
 * `M MM` – month number: `1..12`
-* `MMM MMM` – month: `Jan..December`
+* `MMM MMMM` – month: `Jan..December`
 * `D DD` – day of month: `1..31`
 * `Do` – day of month with ordinal: `1st..31st`
 * `ddd dddd` – day of week: `Tue Tuesday`


### PR DESCRIPTION
To display the full name of the month (like January, not Jan), we need to use four Ms, not three.