### PR TITLE
Update file-storage.md

### DIFF
--- a/docs/administration/file-storage.md
+++ b/docs/administration/file-storage.md
@@ -25,7 +25,7 @@ Parameters need to be set in `data/config-internal.php`:
   ],
 ```
 
-In `data/config.php`:
+In `data/config-internal.php`:
 
 ```
   'defaultFileStorage' => 'AwsS3',


### PR DESCRIPTION
The `defaultFileStorage` parameter does not work if it is located in `config.php`. It must be in `config-internal.php`. I don't know if `thumbImageCacheDisabled` needs to be moved as well.