### PR TITLE
Correction of string\trim() function in the example

### DIFF
--- a/docs/administration/formula/string.md
+++ b/docs/administration/formula/string.md
@@ -104,7 +104,7 @@ Strips whitespace from the beginning and end of STRING.
 !!! example
 
     ```
-    string\length(' hello world ') // will return `hello world`
+    string\trim(' hello world ') // will return `hello world`
     ```
 
 ## string\lowerCase


### PR DESCRIPTION
Changed `string\length` to `string\trim`.