### PR TITLE
attributes link fixed

### DIFF
--- a/docs/administration/formula.md
+++ b/docs/administration/formula.md
@@ -26,7 +26,7 @@ In this article:
 * [Syntax](#syntax)
 * [Operators](#operators)
 * [Control structures](#control-structures)
-* [Attributes](#operators)
+* [Attributes](#attributes)
 * [Functions](#functions)
   * [General](#general)
   * [String](#string)


### PR DESCRIPTION
Fixed the link, which incorrectly led to the Operators section, not Attributes one.