### PR TITLE
Removed extra closing curly brace in the code

### DIFF
--- a/docs/development/modal.md
+++ b/docs/development/modal.md
@@ -105,7 +105,6 @@ define('custom:views/modals/my-dialog', ['views/modal', 'model'], function (Dep,
                     this.trigger('done', response);
                     this.close();
                 });
-            }
         },
     });
 });


### PR DESCRIPTION
There's an extra brace at the end of the actionDoSomething() function.