### PR TITLE
Changed Docker installation doc to MariaDB

### DIFF
--- a/docs/administration/docker/installation.md
+++ b/docs/administration/docker/installation.md
@@ -26,7 +26,7 @@ $ docker run --detach --name mariadb --env MARIADB_ROOT_PASSWORD=password  maria
 Run EspoCRM container:
 
 ```
-$ docker run --name my-espocrm --link mariadb:mariadb -d espocrm/espocrm
+$ docker run --name my-espocrm --link mariadb:mariadb --env ESPOCRM_DATABASE_HOST=mariadb -d espocrm/espocrm
 ```
 
 - `my-espocrm` — name of EspoCRM container,


### PR DESCRIPTION
Changed the installation documentation for docker to MariaDB.

Reason for this is, that the current documentation still uses "mysql_native_password" with is deprecated and will be removed. 
Instead of just removing this, I switched the docs to MariaDB to be more consistent with the example [docker-compose.yml](https://github.com/espocrm/espocrm-docker#usage) from the [espocrm-docker](https://github.com/espocrm/espocrm-docker) repo.

I had to add the `ESPOCRM_DATABASE_HOST=mariadb` as env for the EspoCRM container, as the default hostname is `mysql`.
Changing the default hostname in the [espocrm-docker](https://github.com/espocrm/espocrm-docker) project would probably kill some installations (if they are using the default settings). So I would not recommend that. 