### PR TITLE
Update setting-up.md regarding admin consent

### DIFF
--- a/docs/extensions/outlook-integration/setting-up.md
+++ b/docs/extensions/outlook-integration/setting-up.md
@@ -66,7 +66,7 @@ Permissions that need to be enabled:
 
 ![Permissions](../../_static/images/extensions/outlook-integration/setting-up/10.png)
 
-After adding the above listed API permissions, click Grant Admin Consent for (your organization).
+After adding the above listed API permissions, click Grant Admin Consent for (your organization). **Important**: It may be necessary to Grant Admin Consent again if new users are added to the Microsoft 365 tenant even if the app registration shows admin consent has been granted to the tenant. Attempting to connect a new user to the Outlook Extension in EspoCRM may result in a 403 error from Microsoft Graph, which includes a message about invalid credentials. However, the same error applies to both situations: invalid credentials and lack of admin consent.
 
 
 ## Access control

--- a/docs/extensions/outlook-integration/setting-up.md
+++ b/docs/extensions/outlook-integration/setting-up.md
@@ -66,7 +66,11 @@ Permissions that need to be enabled:
 
 ![Permissions](../../_static/images/extensions/outlook-integration/setting-up/10.png)
 
-After adding the above listed API permissions, click Grant Admin Consent for (your organization). **Important**: It may be necessary to Grant Admin Consent again if new users are added to the Microsoft 365 tenant even if the app registration shows admin consent has been granted to the tenant. Attempting to connect a new user to the Outlook Extension in EspoCRM may result in a 403 error from Microsoft Graph, which includes a message about invalid credentials. However, the same error applies to both situations: invalid credentials and lack of admin consent.
+After adding the above listed API permissions, click Grant Admin Consent for (your organization).
+
+!!! note
+
+    It may be necessary to Grant Admin Consent again if new users are added to the Microsoft 365 tenant even if the app registration shows admin consent has been granted to the tenant. Attempting to connect a new user to the Outlook Extension in EspoCRM may result in a 403 error from Microsoft Graph, which includes a message about invalid credentials. However, the same error applies to both situations: invalid credentials and lack of admin consent.
 
 
 ## Access control


### PR DESCRIPTION
I ran into an error with the Outlook extension regarding admin consent. In my case, I had to grant consent to the organization after adding a new user even though I had already granted admin consent in the past. The new user received a 403 error after clicking the 'Connect' button in EspoCRM. I spent hours working on this until I finally tried the admin consent button again, which immediately fixed the issue. I filed a bug with Microsoft, but I doubt they will do anything about this.