### PR TITLE
Update ext.md

### DIFF
--- a/docs/administration/formula/ext.md
+++ b/docs/administration/formula/ext.md
@@ -160,6 +160,7 @@ new password. This function is useful when creating a new user via formula. (as 
         'userName', $userName,
         'firstName', $firstName,
         'lastName', $lastName,
+        'emailAddress', $emailAddress,
         'type', 'portal',
         'portalsIds', list($portalId)
     );


### PR DESCRIPTION
"ext\user\sendAccessInfo" sending login/password credentials directly to the email address of the created user. Before this change, there was no "emailAddress" value after creation to send information to.